### PR TITLE
Fix USE_IMGUI_TABLES

### DIFF
--- a/ImGuiFileDialog/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog/ImGuiFileDialog.cpp
@@ -1057,8 +1057,8 @@ namespace igfd
 				ExploreWithkeys();
 #endif
 #ifdef USE_IMGUI_TABLES
-				}
 				ImGui::EndTable();
+				}
 #endif
 				// changement de repertoire
 				if (pathClick)


### PR DESCRIPTION
`ImGui::EndTable()` should be called inside the `if (ImGui::BeginTable())` statement otherwise it sometimes crashes.