### PR TITLE
Fix ComposeNewPath() for UNIX

### DIFF
--- a/ImGuiFileDialog/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog/ImGuiFileDialog.cpp
@@ -1903,11 +1903,11 @@ namespace igfd
 #elif defined(UNIX) // UNIX is LINUX or APPLE
 				if (*vIter == s_fs_root)
 				{
-					m_CurrentPath = *vIter + m_CurrentPath;
+					res = *vIter + res;
 				}
 				else
 				{
-					m_CurrentPath = *vIter + PATH_SEP + m_CurrentPath;
+					res = *vIter + PATH_SEP + res;
 				}
 #endif
 			}
@@ -1919,8 +1919,8 @@ namespace igfd
 			if (vIter == m_CurrentPath_Decomposition.begin())
 			{
 #if defined(UNIX) // UNIX is LINUX or APPLE
-				if (m_CurrentPath[0] != PATH_SEP)
-					m_CurrentPath = PATH_SEP + m_CurrentPath;
+				if (res[0] != PATH_SEP)
+					res = PATH_SEP + res;
 #endif
 				break;
 			}


### PR DESCRIPTION
The path component buttons did not work correctly for me on Linux. It seems that the issue was that `ComposeNewPath()` had been changed in commit 6cb056449ce437f7ffbd8efa2c455cf99423a364 to use a local variable `res` instead of accumulating onto `m_CurrentPath` directly, but it was forgotten to implement this change for the UNIX case as well. This PR updates the function to use `res` instead of `m_CurrentPath` also in the UNIX case.