### PR TITLE
Make IGFD::FileDialog's destructor virtual

### DIFF
--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -665,7 +665,7 @@ namespace IGFD
 
 	public:
 		FileDialog();												// ImGuiFileDialog Constructor. can be used for have many dialog at same tiem (not possible with singleton)
-		~FileDialog();												// ImGuiFileDialog Destructor
+		virtual ~FileDialog();										// ImGuiFileDialog Destructor
 
 		// standard dialog
 		void OpenDialog(											// open simple dialog (path and fileName can be specified)


### PR DESCRIPTION
Hi and thanks for the great library!

I noticed a compilation warning caused by the fact that `IGFD::FileDialog` has virtual member functions and a non-virtual destructor:
```
$ clang++ -c ImGuiFileDialog.cpp -I../imgui -Wall
ImGuiFileDialog.cpp:2972:3: warning: delete called on non-final 'IGFD::FileDialog' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
                delete vContext;
                ^
1 warning generated.
```
While it's not critically important, I made the destructor virtual to avoid any trouble it might cause down the road. I hope this helps somehow :)