### PR TITLE
Switch ImGuiFileDialog url to .git suffix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = master
 [submodule "ImGuiFileDialog"]
 	path = ImGuiFileDialog
-	url = https://github.com/aiekick/ImGuiFileDialog/
+	url = https://github.com/aiekick/ImGuiFileDialog.git
 	branch = Lib_Only


### PR DESCRIPTION
My colleagues aren't having this issue, but this trailing slash is preventing me from updating git submodules. Adding `.git` also matches the other urls. 

Signed-off-by: Stephen Brawner <brawner@gmail.com>