### PR TITLE
Collection of upgrades

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3800,7 +3800,10 @@ namespace IGFD
 		if (!fdFile.puDLGDirectoryMode)
 			width -= FILTER_COMBO_WIDTH;
 		ImGui::PushItemWidth(width);
-		ImGui::InputText("##FileName", fdFile.puFileNameBuffer, MAX_FILE_DIALOG_NAME_BUFFER);
+		
+		if (ImGui::InputText("##FileName", fdFile.puFileNameBuffer, MAX_FILE_DIALOG_NAME_BUFFER, ImGuiInputTextFlags_EnterReturnsTrue))
+			prFileDialogInternal.puIsOk = true;
+
 		if (ImGui::GetItemID() == ImGui::GetActiveID())
 			prFileDialogInternal.puFileInputIsActive = true;
 		ImGui::PopItemWidth();

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3043,7 +3043,7 @@ namespace IGFD
 
 							if (enterInDirectory)
 							{
-								prFileDialogInternal.puIsOk = true;
+								vFileDialogInternal.puIsOk = true;
 							}
 						}
 
@@ -3824,8 +3824,17 @@ namespace IGFD
 			width -= FILTER_COMBO_WIDTH;
 		ImGui::PushItemWidth(width);
 		
-		if (ImGui::InputText("##FileName", fdFile.puFileNameBuffer, MAX_FILE_DIALOG_NAME_BUFFER, ImGuiInputTextFlags_EnterReturnsTrue))
+		ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue;
+		
+		if (prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_ReadOnlyFileNameField)
+		{
+			flags |= ImGuiInputTextFlags_ReadOnly;
+		}
+
+		if (ImGui::InputText("##FileName", fdFile.puFileNameBuffer, MAX_FILE_DIALOG_NAME_BUFFER, flags))
+		{
 			prFileDialogInternal.puIsOk = true;
+		}
 
 		if (ImGui::GetItemID() == ImGui::GetActiveID())
 			prFileDialogInternal.puFileInputIsActive = true;

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -1280,6 +1280,7 @@ namespace IGFD
 							return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) > 0); // sort in insensitive case
 						}
 						*/
+						if (a->fileType != b->fileType) return (a->fileType != 'd'); // directories last
 						return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) > 0); // sort in insensitive case
 					});
 			}

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -188,6 +188,18 @@ namespace IGFD
 #ifndef tableHeaderFileDateString
 #define tableHeaderFileDateString "Date"
 #endif // tableHeaderFileDateString
+#ifndef fileSizeBytes
+#define fileSizeBytes "o"
+#endif // fileSizeBytes
+#ifndef fileSizeKiloBytes
+#define fileSizeKiloBytes "Ko"
+#endif // fileSizeKiloBytes
+#ifndef fileSizeMegaBytes
+#define fileSizeMegaBytes "Mo"
+#endif // fileSizeMegaBytes
+#ifndef fileSizeGigaBytes
+#define fileSizeGigaBytes "Go"
+#endif // fileSizeGigaBytes
 #ifndef OverWriteDialogTitleString
 #define OverWriteDialogTitleString "The file Already Exist !"
 #endif // OverWriteDialogTitleString
@@ -1687,13 +1699,13 @@ namespace IGFD
 			auto v = (double)vByteSize;
 
 			if (v < lo)
-				return prRoundNumber(v, 0) + " o"; // octet
+				return prRoundNumber(v, 0) + " " + fileSizeBytes; // octet
 			else if (v < ko)
-				return prRoundNumber(v / lo, 2) + " Ko"; // ko
+				return prRoundNumber(v / lo, 2) + " " + fileSizeKiloBytes; // ko
 			else  if (v < mo)
-				return prRoundNumber(v / ko, 2) + " Mo"; // Mo 
+				return prRoundNumber(v / ko, 2) + " " + fileSizeMegaBytes; // Mo
 			else
-				return prRoundNumber(v / mo, 2) + " Go"; // Go 
+				return prRoundNumber(v / mo, 2) + " " + fileSizeGigaBytes; // Go
 		}
 
 		return "";

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3039,6 +3039,11 @@ namespace IGFD
 						else
 						{
 							fdi.SelectFileName(vFileDialogInternal, infos);
+
+							if (enterInDirectory)
+							{
+								prFileDialogInternal.puIsOk = true;
+							}
 						}
 
 						if (exitDirectory)

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3813,7 +3813,7 @@ namespace IGFD
 		// OK Button
 		if (prFileDialogInternal.puCanWeContinue && strlen(fdFile.puFileNameBuffer))
 		{
-			if (IMGUI_BUTTON(okButtonString "##validationdialog"))
+			if (IMGUI_BUTTON(okButtonString "##validationdialog") || prFileDialogInternal.puIsOk)
 			{
 				prFileDialogInternal.puIsOk = true;
 				res = true;
@@ -3899,6 +3899,11 @@ namespace IGFD
 			else
 			{
 				fdi.SelectFileName(prFileDialogInternal, vInfos);
+
+				if (ImGui::IsMouseDoubleClicked(0))
+				{
+					prFileDialogInternal.puIsOk = true;
+				}
 			}
 		}
 

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -563,8 +563,13 @@ namespace IGFD
 
 		auto fsPath = fs::path(vPathFileName);
 
-		if (fs::is_regular_file(fsPath)) {
-			res.name = fsPath.string();
+		if (fs::is_directory(fsPath)) {
+			res.name = "";
+			res.path = fsPath.string();
+			res.isOk = true;
+
+		} else if (fs::is_regular_file(fsPath)) {
+			res.name = fsPath.filename().string();
 			res.path = fsPath.parent_path().string();
 			res.isOk = true;
 		}
@@ -3332,7 +3337,7 @@ namespace IGFD
 		if (ps.isOk)
 		{
 			prFileDialogInternal.puFileManager.puDLGpath = ps.path;
-			prFileDialogInternal.puFileManager.SetDefaultFileName(vFilePathName);
+			prFileDialogInternal.puFileManager.SetDefaultFileName(ps.name);
 			prFileDialogInternal.puFilterManager.puDLGdefaultExt = "." + ps.ext;
 		}
 		else

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -655,6 +655,26 @@ struct IGFD_Thumbnail_Info
 
 namespace IGFD
 {
+#ifndef defaultSortField
+#define defaultSortField FIELD_FILENAME
+#endif // defaultSortField
+
+#ifndef defaultSortOrderFilename
+#define defaultSortOrderFilename true
+#endif // defaultSortOrderFilename
+#ifndef defaultSortOrderType
+#define defaultSortOrderType true
+#endif // defaultSortOrderType
+#ifndef defaultSortOrderSize
+#define defaultSortOrderSize true
+#endif // defaultSortOrderSize
+#ifndef defaultSortOrderDate
+#define defaultSortOrderDate true
+#endif // defaultSortOrderDate
+#ifndef defaultSortOrderThumbnails
+#define defaultSortOrderThumbnails true
+#endif // defaultSortOrderThumbnails
+
 #ifndef MAX_FILE_DIALOG_NAME_BUFFER 
 #define MAX_FILE_DIALOG_NAME_BUFFER 1024
 #endif // MAX_FILE_DIALOG_NAME_BUFFER
@@ -863,9 +883,18 @@ namespace IGFD
 		std::string puHeaderFileDate;										// detail view name of column date + time
 #ifdef USE_THUMBNAILS
 		std::string puHeaderFileThumbnails;									// detail view name of column thumbnails
-		bool puSortingDirection[5] = { true, true, true, true, true };		// detail view // true => Descending, false => Ascending
+		bool puSortingDirection[5] = {										// detail view // true => Descending, false => Ascending
+			defaultSortOrderFilename,
+			defaultSortOrderType,
+			defaultSortOrderSize,
+			defaultSortOrderDate,
+			defaultSortOrderThumbnails };
 #else
-		bool puSortingDirection[4] = { true, true, true, true };			// detail view // true => Descending, false => Ascending
+		bool puSortingDirection[4] = {										// detail view // true => Descending, false => Ascending
+			defaultSortOrderFilename,
+			defaultSortOrderType,
+			defaultSortOrderSize,
+			defaultSortOrderDate };
 #endif
 		SortingFieldEnum puSortingField = SortingFieldEnum::FIELD_FILENAME;	// detail view sorting column
 		bool puShowDrives = false;											// drives are shown (only on os windows)

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -615,6 +615,8 @@ enum ImGuiFileDialogFlags_
 #ifdef USE_THUMBNAILS
 	ImGuiFileDialogFlags_DisableThumbnailMode = (1 << 6),						// disable the thumbnail mode
 #endif
+	ImGuiFileDialogFlags_ReadOnlyFileNameField = (1 << 7),						// don't let user type in filename field
+																				// for file open style dialogs
 	ImGuiFileDialogFlags_Default = ImGuiFileDialogFlags_ConfirmOverwrite
 };
 

--- a/ImGuiFileDialogConfig.h
+++ b/ImGuiFileDialogConfig.h
@@ -88,6 +88,16 @@
 //#define tableHeaderFileSizeString " Size"
 //#define tableHeaderFileDateTimeString " Date"
 
+// default table sort field (must be FIELD_FILENAME, FIELD_TYPE, FIELD_SIZE, FIELD_DATE or FIELD_THUMBNAILS)
+//#define defaultSortField FIELD_FILENAME
+
+// default table sort order for each field (true => Descending, false => Ascending)
+//#define defaultSortOrderFilename true
+//#define defaultSortOrderType true
+//#define defaultSortOrderSize true
+//#define defaultSortOrderDate true
+//#define defaultSortOrderThumbnails true
+
 //#define USE_BOOKMARK
 //#define bookmarkPaneWith 150.0f
 //#define IMGUI_TOGGLE_BUTTON ToggleButton

--- a/ImGuiFileDialogConfig.h
+++ b/ImGuiFileDialogConfig.h
@@ -87,6 +87,10 @@
 //#define tableHeaderFileTypeString " Type"
 //#define tableHeaderFileSizeString " Size"
 //#define tableHeaderFileDateTimeString " Date"
+//#define fileSizeBytes "o"
+//#define fileSizeKiloBytes "Ko"
+//#define fileSizeMegaBytes "Mo"
+//#define fileSizeGigaBytes "Go"
 
 // default table sort field (must be FIELD_FILENAME, FIELD_TYPE, FIELD_SIZE, FIELD_DATE or FIELD_THUMBNAILS)
 //#define defaultSortField FIELD_FILENAME


### PR DESCRIPTION
Thanks for a great library! This pull request offers a number of enhancements:

* Support configurable sort field and sort order by field. The default descending sort by filename wasn't working for me so I added a compile-time configuration option to pick the default sort field as well as the default sort order per field. The default is the old behavior.
* Allow double click to select a file. This was possible in the past but it was lost during the thumbnail rewrite.
* Pressing return while in the filename field now selects the file. No need to click OK.
* Better handling when directories are passed as the vFileName parameter of OpenDialog.
* Allow customization of file size acronyms. Ko, Mo, Go were not working for me. Compile-time configuration options can change the acronyms. The default is the old behavior. I'm now using bytes, KB, MB and GB, just like my Mac.
* While exploring with keys, pressing enter now selects the file.
* Fixed ascending filename sort order. It did not take care of directories vs files.
* Added a new flag to the open call to make the filename field readonly to support "Open File.." cases where you don't want the user to type something that doesn't exist.