### PR TITLE
Made column sort consistent with ImGui and across configuration options

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3792,6 +3792,8 @@ namespace IGFD
 		
 		float posY = ImGui::GetCursorPos().y; // height of last bar calc
 
+		ImGui::AlignTextToFramePadding();
+
 		if (!fdFile.puDLGDirectoryMode)
 			ImGui::Text(fileNameString);
 		else // directory chooser

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -2931,7 +2931,11 @@ namespace IGFD
 			if (g.NavId && g.NavId == vListViewID)
 			{
 				if (ImGui::IsKeyPressedMap(ImGuiKey_Enter) ||
+#if IMGUI_VERSION_NUM > 18600
+					ImGui::IsKeyPressedMap(ImGuiKey_KeypadEnter) ||
+#else
 					ImGui::IsKeyPressedMap(ImGuiKey_KeyPadEnter) ||
+#endif
 					ImGui::IsKeyPressedMap(ImGuiKey_Space))
 				{
 					ImGui::ActivateItem(vListViewID);
@@ -3969,6 +3973,7 @@ namespace IGFD
 			ImGuiTableFlags_Hideable | ImGuiTableFlags_ScrollY |
 			ImGuiTableFlags_NoHostExtendY
 #ifndef USE_CUSTOM_SORTING_ICON
+			| ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoBordersInBody
 			| ImGuiTableFlags_Sortable
 #endif // USE_CUSTOM_SORTING_ICON
 			;
@@ -4165,6 +4170,7 @@ namespace IGFD
 			ImGuiTableFlags_Hideable | ImGuiTableFlags_ScrollY |
 			ImGuiTableFlags_NoHostExtendY
 #ifndef USE_CUSTOM_SORTING_ICON
+			| ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoBordersInBody
 			| ImGuiTableFlags_Sortable
 #endif // USE_CUSTOM_SORTING_ICON
 			;

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -1208,9 +1208,9 @@ namespace IGFD
 		ScanDir(vFileDialogInternal, GetCurrentPath());
 	}
 
-	void IGFD::FileManager::SortFields(const FileDialogInternal& vFileDialogInternal, const SortingFieldEnum& vSortingField, const bool& vCanChangeOrder)
+	void IGFD::FileManager::SortFields(const FileDialogInternal& vFileDialogInternal)
 	{
-		if (vSortingField != SortingFieldEnum::FIELD_NONE)
+		if (puSortingField != SortingFieldEnum::FIELD_NONE)
 		{
 			puHeaderFileName = tableHeaderFileNameString;
 			puHeaderFileType = tableHeaderFileTypeString;
@@ -1221,15 +1221,12 @@ namespace IGFD
 #endif // #ifdef USE_THUMBNAILS
 		}
 
-		if (vSortingField == SortingFieldEnum::FIELD_FILENAME)
+		if (puSortingField == SortingFieldEnum::FIELD_FILENAME)
 		{
-			if (vCanChangeOrder && puSortingField == vSortingField)
-				puSortingDirection[0] = !puSortingDirection[0];
-
 			if (puSortingDirection[0])
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileName = tableHeaderDescendingIcon + puHeaderFileName;
+				puHeaderFileName = tableHeaderAscendingIcon + puHeaderFileName;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1258,7 +1255,7 @@ namespace IGFD
 			else
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileName = tableHeaderAscendingIcon + puHeaderFileName;
+				puHeaderFileName = tableHeaderDescendingIcon + puHeaderFileName;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1285,15 +1282,12 @@ namespace IGFD
 					});
 			}
 		}
-		else if (vSortingField == SortingFieldEnum::FIELD_TYPE)
+		else if (puSortingField == SortingFieldEnum::FIELD_TYPE)
 		{
-			if (vCanChangeOrder && puSortingField == vSortingField)
-				puSortingDirection[1] = !puSortingDirection[1];
-
 			if (puSortingDirection[1])
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileType = tableHeaderDescendingIcon + puHeaderFileType;
+				puHeaderFileType = tableHeaderAscendingIcon + puHeaderFileType;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1308,7 +1302,7 @@ namespace IGFD
 			else
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileType = tableHeaderAscendingIcon + puHeaderFileType;
+				puHeaderFileType = tableHeaderDescendingIcon + puHeaderFileType;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1321,15 +1315,12 @@ namespace IGFD
 					});
 			}
 		}
-		else if (vSortingField == SortingFieldEnum::FIELD_SIZE)
+		else if (puSortingField == SortingFieldEnum::FIELD_SIZE)
 		{
-			if (vCanChangeOrder && puSortingField == vSortingField)
-				puSortingDirection[2] = !puSortingDirection[2];
-
 			if (puSortingDirection[2])
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileSize = tableHeaderDescendingIcon + puHeaderFileSize;
+				puHeaderFileSize = tableHeaderAscendingIcon + puHeaderFileSize;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1344,7 +1335,7 @@ namespace IGFD
 			else
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileSize = tableHeaderAscendingIcon + puHeaderFileSize;
+				puHeaderFileSize = tableHeaderDescendingIcon + puHeaderFileSize;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1357,15 +1348,12 @@ namespace IGFD
 					});
 			}
 		}
-		else if (vSortingField == SortingFieldEnum::FIELD_DATE)
+		else if (puSortingField == SortingFieldEnum::FIELD_DATE)
 		{
-			if (vCanChangeOrder && puSortingField == vSortingField)
-				puSortingDirection[3] = !puSortingDirection[3];
-
 			if (puSortingDirection[3])
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileDate = tableHeaderDescendingIcon + puHeaderFileDate;
+				puHeaderFileDate = tableHeaderAscendingIcon + puHeaderFileDate;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1380,7 +1368,7 @@ namespace IGFD
 			else
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileDate = tableHeaderAscendingIcon + puHeaderFileDate;
+				puHeaderFileDate = tableHeaderDescendingIcon + puHeaderFileDate;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1394,11 +1382,8 @@ namespace IGFD
 			}
 		}
 #ifdef USE_THUMBNAILS
-		else if (vSortingField == SortingFieldEnum::FIELD_THUMBNAILS)
+		else if (puSortingField == SortingFieldEnum::FIELD_THUMBNAILS)
 		{
-			if (vCanChangeOrder && puSortingField == vSortingField)
-				puSortingDirection[4] = !puSortingDirection[4];
-
 			// we will compare thumbnails by :
 			// 1) width 
 			// 2) height
@@ -1406,7 +1391,7 @@ namespace IGFD
 			if (puSortingDirection[4])
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileThumbnails = tableHeaderDescendingIcon + puHeaderFileThumbnails;
+				puHeaderFileThumbnails = tableHeaderAscendingIcon + puHeaderFileThumbnails;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1424,7 +1409,7 @@ namespace IGFD
 			else
 			{
 #ifdef USE_CUSTOM_SORTING_ICON
-				puHeaderFileThumbnails = tableHeaderAscendingIcon + puHeaderFileThumbnails;
+				puHeaderFileThumbnails = tableHeaderDescendingIcon + puHeaderFileThumbnails;
 #endif // USE_CUSTOM_SORTING_ICON
 				std::sort(prFileList.begin(), prFileList.end(),
 					[](const std::shared_ptr<FileInfos>& a, const std::shared_ptr<FileInfos>& b) -> bool
@@ -1440,11 +1425,6 @@ namespace IGFD
 			}
 		}
 #endif // USE_THUMBNAILS
-
-		if (vSortingField != SortingFieldEnum::FIELD_NONE)
-		{
-			puSortingField = vSortingField;
-		}
 
 		ApplyFilteringOnFileList(vFileDialogInternal);
 	}
@@ -1570,7 +1550,7 @@ namespace IGFD
 			}
 #endif // USE_STD_FILESYSTEM
 
-			SortFields(vFileDialogInternal, puSortingField, false);
+			SortFields(vFileDialogInternal);
 		}
 	}
 
@@ -3726,6 +3706,7 @@ namespace IGFD
 #ifdef USE_BOOKMARK
 		prDrawBookmarkButton();
 		ImGui::SameLine();
+
 #endif // USE_BOOKMARK
 
 		prFileDialogInternal.puFileManager.DrawDirectoryCreation(prFileDialogInternal);
@@ -3995,12 +3976,16 @@ namespace IGFD
 		if (ImGui::BeginTableEx("##FileDialog_fileTable", listViewID, 4, flags, vSize, 0.0f)) //-V112
 		{
 			ImGui::TableSetupScrollFreeze(0, 1); // Make header always visible
-			ImGui::TableSetupColumn(fdi.puHeaderFileName.c_str(), ImGuiTableColumnFlags_WidthStretch, -1, 0);
-			ImGui::TableSetupColumn(fdi.puHeaderFileType.c_str(), ImGuiTableColumnFlags_WidthFixed | 
+			ImGui::TableSetupColumn(fdi.puHeaderFileName.c_str(), ImGuiTableColumnFlags_WidthStretch |
+				(defaultSortOrderFilename ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending), -1, 0);
+			ImGui::TableSetupColumn(fdi.puHeaderFileType.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderType ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnType) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 1);
-			ImGui::TableSetupColumn(fdi.puHeaderFileSize.c_str(), ImGuiTableColumnFlags_WidthFixed | 
+			ImGui::TableSetupColumn(fdi.puHeaderFileSize.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderSize ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnSize) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 2);
-			ImGui::TableSetupColumn(fdi.puHeaderFileDate.c_str(), ImGuiTableColumnFlags_WidthFixed | 
+			ImGui::TableSetupColumn(fdi.puHeaderFileDate.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderDate ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnDate) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 3);
 
 #ifndef USE_CUSTOM_SORTING_ICON
@@ -4009,14 +3994,32 @@ namespace IGFD
 			{
 				if (sorts_specs->SpecsDirty && !fdi.IsFileListEmpty())
 				{
+					bool direction = sorts_specs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+
 					if (sorts_specs->Specs->ColumnUserID == 0)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME;
+						fdi.puSortingDirection[0] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (sorts_specs->Specs->ColumnUserID == 1)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_TYPE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_TYPE;
+						fdi.puSortingDirection[1] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (sorts_specs->Specs->ColumnUserID == 2)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_SIZE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_SIZE;
+						fdi.puSortingDirection[2] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else //if (sorts_specs->Specs->ColumnUserID == 3) => alwayd true for the moment, to uncomment if we add a fourth column
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_DATE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_DATE;
+						fdi.puSortingDirection[3] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 
 					sorts_specs->SpecsDirty = false;
 				}
@@ -4035,13 +4038,41 @@ namespace IGFD
 				if (ImGui::IsItemClicked())
 				{
 					if (column == 0)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME)
+							fdi.puSortingDirection[0] = !fdi.puSortingDirection[0];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME;
+
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (column == 1)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_TYPE, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_TYPE)
+							fdi.puSortingDirection[1] = !fdi.puSortingDirection[1];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_TYPE;
+
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (column == 2)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_SIZE, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_SIZE)
+							fdi.puSortingDirection[2] = !fdi.puSortingDirection[2];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_SIZE;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else //if (column == 3) => alwayd true for the moment, to uncomment if we add a fourth column
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_DATE, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_DATE)
+							fdi.puSortingDirection[3] = !fdi.puSortingDirection[3];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_DATE;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 				}
 			}
 #endif // USE_CUSTOM_SORTING_ICON
@@ -4141,15 +4172,20 @@ namespace IGFD
 		if (ImGui::BeginTableEx("##FileDialog_fileTable", listViewID, 5, flags, vSize, 0.0f))
 		{
 			ImGui::TableSetupScrollFreeze(0, 1); // Make header always visible
-			ImGui::TableSetupColumn(fdi.puHeaderFileName.c_str(), ImGuiTableColumnFlags_WidthStretch, -1, 0);
+			ImGui::TableSetupColumn(fdi.puHeaderFileName.c_str(), ImGuiTableColumnFlags_WidthStretch |
+				(defaultSortOrderFilename ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending), -1, 0);
 			ImGui::TableSetupColumn(fdi.puHeaderFileType.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderType ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnType) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 1);
 			ImGui::TableSetupColumn(fdi.puHeaderFileSize.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderSize ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnSize) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 2);
 			ImGui::TableSetupColumn(fdi.puHeaderFileDate.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderDate ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending) |
 				((prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_HideColumnDate) ? ImGuiTableColumnFlags_DefaultHide : 0), -1, 3);
 			// not needed to have an option for hide the thumbnails since this is why this view is used
-			ImGui::TableSetupColumn(fdi.puHeaderFileThumbnails.c_str(), ImGuiTableColumnFlags_WidthFixed, -1, 4); //-V112
+			ImGui::TableSetupColumn(fdi.puHeaderFileThumbnails.c_str(), ImGuiTableColumnFlags_WidthFixed |
+				(defaultSortOrderThumbnails ? ImGuiTableColumnFlags_PreferSortAscending : ImGuiTableColumnFlags_PreferSortDescending), -1, 4); //-V112
 
 #ifndef USE_CUSTOM_SORTING_ICON
 			// Sort our data if sort specs have been changed!
@@ -4157,16 +4193,39 @@ namespace IGFD
 			{
 				if (sorts_specs->SpecsDirty && !fdi.IsFileListEmpty())
 				{
+					bool direction = sorts_specs->Specs->SortDirection == ImGuiSortDirection_Ascending;
+					
 					if (sorts_specs->Specs->ColumnUserID == 0)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME;
+						fdi.puSortingDirection[0] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (sorts_specs->Specs->ColumnUserID == 1)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_TYPE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_TYPE;
+						fdi.puSortingDirection[1] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (sorts_specs->Specs->ColumnUserID == 2)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_SIZE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_SIZE;
+						fdi.puSortingDirection[2] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (sorts_specs->Specs->ColumnUserID == 3)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_DATE, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_DATE;
+						fdi.puSortingDirection[3] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else // if (sorts_specs->Specs->ColumnUserID == 4) = > always true for the moment, to uncomment if we add another column
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_THUMBNAILS, true);
+					{
+						fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_THUMBNAILS;
+						fdi.puSortingDirection[4] = direction;
+						fdi.SortFields(prFileDialogInternal);
+					}
+
 					sorts_specs->SpecsDirty = false;
 				}
 			}
@@ -4184,15 +4243,50 @@ namespace IGFD
 				if (ImGui::IsItemClicked())
 				{
 					if (column == 0)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME)
+							fdi.puSortingDirection[0] = !fdi.puSortingDirection[0];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_FILENAME;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (column == 1)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_TYPE, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_TYPE)
+							fdi.puSortingDirection[1] = !fdi.puSortingDirection[1];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_TYPE;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (column == 2)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_SIZE, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_SIZE)
+							fdi.puSortingDirection[2] = !fdi.puSortingDirection[2];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_SIZE;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 					else if (column == 3)
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_DATE, true);
-					else // if (column == 4) = > always true for the moment, to uncomment if we add another column
-						fdi.SortFields(prFileDialogInternal, IGFD::FileManager::SortingFieldEnum::FIELD_THUMBNAILS, true);
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_DATE)
+							fdi.puSortingDirection[3] = !fdi.puSortingDirection[3];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_DATE;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
+					else // if (sorts_specs->Specs->ColumnUserID == 4) = > always true for the moment, to uncomment if we add another column
+					{
+						if (fdi.puSortingField == IGFD::FileManager::SortingFieldEnum::FIELD_THUMBNAILS)
+							fdi.puSortingDirection[4] = !fdi.puSortingDirection[4];
+						else
+							fdi.puSortingField = IGFD::FileManager::SortingFieldEnum::FIELD_THUMBNAILS;
+						
+						fdi.SortFields(prFileDialogInternal);
+					}
 				}
 			}
 #endif // USE_CUSTOM_SORTING_ICON

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -2931,11 +2931,7 @@ namespace IGFD
 			if (g.NavId && g.NavId == vListViewID)
 			{
 				if (ImGui::IsKeyPressedMap(ImGuiKey_Enter) ||
-#if IMGUI_VERSION_NUM > 18600
 					ImGui::IsKeyPressedMap(ImGuiKey_KeypadEnter) ||
-#else
-					ImGui::IsKeyPressedMap(ImGuiKey_KeyPadEnter) ||
-#endif
 					ImGui::IsKeyPressedMap(ImGuiKey_Space))
 				{
 					ImGui::ActivateItem(vListViewID);
@@ -3806,7 +3802,11 @@ namespace IGFD
 		// Input file fields
 		float width = ImGui::GetContentRegionAvail().x;
 		if (!fdFile.puDLGDirectoryMode)
-			width -= FILTER_COMBO_WIDTH;
+		{
+			ImGuiContext& g = *GImGui;
+			width -= FILTER_COMBO_WIDTH + g.Style.ItemSpacing.x;
+		}
+
 		ImGui::PushItemWidth(width);
 		
 		ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue;
@@ -3973,7 +3973,6 @@ namespace IGFD
 			ImGuiTableFlags_Hideable | ImGuiTableFlags_ScrollY |
 			ImGuiTableFlags_NoHostExtendY
 #ifndef USE_CUSTOM_SORTING_ICON
-			| ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoBordersInBody
 			| ImGuiTableFlags_Sortable
 #endif // USE_CUSTOM_SORTING_ICON
 			;
@@ -4170,7 +4169,6 @@ namespace IGFD
 			ImGuiTableFlags_Hideable | ImGuiTableFlags_ScrollY |
 			ImGuiTableFlags_NoHostExtendY
 #ifndef USE_CUSTOM_SORTING_ICON
-			| ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoBordersInBody
 			| ImGuiTableFlags_Sortable
 #endif // USE_CUSTOM_SORTING_ICON
 			;

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -885,14 +885,14 @@ namespace IGFD
 		std::string puHeaderFileDate;										// detail view name of column date + time
 #ifdef USE_THUMBNAILS
 		std::string puHeaderFileThumbnails;									// detail view name of column thumbnails
-		bool puSortingDirection[5] = {										// detail view // true => Descending, false => Ascending
+		bool puSortingDirection[5] = {										// true => Ascending, false => Descending
 			defaultSortOrderFilename,
 			defaultSortOrderType,
 			defaultSortOrderSize,
 			defaultSortOrderDate,
 			defaultSortOrderThumbnails };
 #else
-		bool puSortingDirection[4] = {										// detail view // true => Descending, false => Ascending
+		bool puSortingDirection[4] = {										// true => Ascending, false => Descending
 			defaultSortOrderFilename,
 			defaultSortOrderType,
 			defaultSortOrderSize,
@@ -935,8 +935,7 @@ namespace IGFD
 		void ClearAll();
 		void ApplyFilteringOnFileList(const FileDialogInternal& vFileDialogInternal);
 		void OpenCurrentPath(const FileDialogInternal& vFileDialogInternal);							// set the path of the dialog, will launch the directory scan for populate the file listview
-		void SortFields(const FileDialogInternal& vFileDialogInternal, 
-			const SortingFieldEnum& vSortingField, const bool& vCanChangeOrder);						// will sort a column
+		void SortFields(const FileDialogInternal& vFileDialogInternal);									// will sort a column
 		bool GetDrives();																				// list drives on windows platform
 		bool CreateDir(const std::string& vPath);														// create a directory on the file system
 		void ComposeNewPath(std::vector<std::string>::iterator vIter);									// compose a path from the compose path widget


### PR DESCRIPTION
After some more work with this great library, I found out that column sort was not consistent with the way ImGui does it and it was behaving differently depending on whether you use the compile time USE_CUSTOM_SORTING_ICON option or not.  Here are the changes made:

* Ascending (A-Z, 0-9) and descending (Z-A, 9-0) is now used consistently in all configuration options.
* Changing the sort order is no longer performed in the SortFields member function (this caused strange behavior when USE_CUSTOM_SORTING_ICON was NOT selected).
* Without USE_CUSTOM_SORTING_ICON, file lists show an "up triangle" for ascending and a "down triangle" for descending just like other ImGui tables.
* With USE_CUSTOM_SORTING_ICON, file lists show the tableHeaderAscendingIcon (compile time configuration option)  for ascending and  tableHeaderDescendingIcon (compile time configuration option) for descending.
* Default sort options can be specified for each column through the compile time configuration process.

Note 1: Whether you like an up or down icon to represent ascending or descending is a matter of taste. With this pull request, this library becomes consistent with ImGui and a number of operating systems and libraries. The IT community is very divided on this subject as 56% prefers this way and 44% the other way (see https://hackernoon.com/sorting-arrow-confusion-in-data-tables-5a3117698fdf). If you are part of the 44% community, you can use the USE_CUSTOM_SORTING_ICON configuration option to have whatever you want. @aiekick: you need to check if the demo app is still the way you want it.

Note 2: The prDrawFileListView and prDrawThumbnailsListView member functions are almost identical. Merging them would require some #ifdef ugliness but I think it would be easier to maintain the code. Even better would be to do away with the USE_THUMBNAILS compile time configuration option. It really doesn't bloat the library and a runtime configuration is already available to turn thumbnails modes on and off. if @aiekick wants it, I can make a pull request for this as well.