### PR TITLE
Make symlinks appear as regular files or directories.

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -886,13 +886,20 @@ namespace IGFD
 	// will not been exposed to IGFD API
 	bool IGFD::FilterManager::prFillFileStyle(std::shared_ptr<FileInfos> vFileInfos) const
 	{
+		// todo : better system to found regarding what style to priorize regarding other
+		// maybe with a lambda fucntion for let the user use his style
+		// according to his use case
 		if (vFileInfos.use_count() && !prFilesStyle.empty())
 		{
 			for (const auto& _flag : prFilesStyle)
 			{
 				for (const auto& _file : _flag.second)
 				{
-					if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isSymLink())
+					if ((_flag.first & IGFD_FileStyleByTypeDir && _flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isDir() && vFileInfos->fileType.isSymLink()) ||
+						(_flag.first & IGFD_FileStyleByTypeFile && _flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isFile() && vFileInfos->fileType.isSymLink()) ||
+						(_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isSymLink()) ||
+						(_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir()) ||
+						(_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile()))
 					{
 						if (_file.first.empty()) // for all links
 						{
@@ -902,29 +909,7 @@ namespace IGFD
 						{
 							vFileInfos->fileStyle = _file.second;
 						}
-					}
-					else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
-					{
-						if (_file.first.empty()) // for all dirs
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-						else if (_file.first == vFileInfos->fileNameExt) // for dirs who are equal to style criteria
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-					}
-					else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
-					{
-						if (_file.first.empty()) // for all files
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-						else if (_file.first == vFileInfos->fileNameExt) // for files who are equal to style criteria
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-					}					
+					}			
 
 					if (_flag.first & IGFD_FileStyleByExtention)
 					{
@@ -932,29 +917,6 @@ namespace IGFD
 						{
 							vFileInfos->fileStyle = _file.second;
 						}
-
-						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isSymLink())
-						{
-							if (_file.first == vFileInfos->fileExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						// can make sense for some dirs like the hidden by ex ".git"
-						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
-						{
-							if (_file.first == vFileInfos->fileExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
-						{
-							if (_file.first == vFileInfos->fileExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}						
 					}
 					if (_flag.first & IGFD_FileStyleByFullName)
 					{
@@ -962,56 +924,12 @@ namespace IGFD
 						{
 							vFileInfos->fileStyle = _file.second;
 						}
-
-						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isSymLink())
-						{
-							if (_file.first == vFileInfos->fileNameExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
-						{
-							if (_file.first == vFileInfos->fileNameExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
-						{
-							if (_file.first == vFileInfos->fileNameExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}						
 					}
 					if (_flag.first & IGFD_FileStyleByContainedInFullName)
 					{
 						if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
 						{
 							vFileInfos->fileStyle = _file.second;
-						}
-
-						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.isSymLink())
-						{
-							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
-						{
-							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
-						{
-							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
 						}
 					}
 

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -2709,7 +2709,7 @@ namespace IGFD
 				// retrieve datas of the texture file if its an image file
 				if (file.use_count())
 				{
-					if (file->fileType == 'f') //-V522
+					if (file->fileType.isFile()) //-V522
 					{
 						if (file->fileExt == ".png"
 							|| file->fileExt == ".bmp"
@@ -2816,7 +2816,7 @@ namespace IGFD
 	{
 		if (vFileInfos.use_count())
 		{
-			if (vFileInfos->fileType == 'f')
+			if (vFileInfos->fileType.isFile())
 			{
 				if (vFileInfos->fileExt == ".png"
 					|| vFileInfos->fileExt == ".bmp"

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -892,29 +892,7 @@ namespace IGFD
 			{
 				for (const auto& _file : _flag.second)
 				{
-					if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType == 'd')
-					{
-						if (_file.first.empty()) // for all dirs
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-						else if (_file.first == vFileInfos->fileNameExt) // for dirs who are equal to style criteria
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-					}
-					else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType == 'f')
-					{
-						if (_file.first.empty()) // for all files
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-						else if (_file.first == vFileInfos->fileNameExt) // for files who are equal to style criteria
-						{
-							vFileInfos->fileStyle = _file.second;
-						}
-					}
-					else if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType == 'l')
+					if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.symlink)
 					{
 						if (_file.first.empty()) // for all links
 						{
@@ -925,6 +903,28 @@ namespace IGFD
 							vFileInfos->fileStyle = _file.second;
 						}
 					}
+					else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
+					{
+						if (_file.first.empty()) // for all dirs
+						{
+							vFileInfos->fileStyle = _file.second;
+						}
+						else if (_file.first == vFileInfos->fileNameExt) // for dirs who are equal to style criteria
+						{
+							vFileInfos->fileStyle = _file.second;
+						}
+					}
+					else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
+					{
+						if (_file.first.empty()) // for all files
+						{
+							vFileInfos->fileStyle = _file.second;
+						}
+						else if (_file.first == vFileInfos->fileNameExt) // for files who are equal to style criteria
+						{
+							vFileInfos->fileStyle = _file.second;
+						}
+					}					
 
 					if (_flag.first & IGFD_FileStyleByExtention)
 					{
@@ -933,28 +933,28 @@ namespace IGFD
 							vFileInfos->fileStyle = _file.second;
 						}
 
+						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.symlink)
+						{
+							if (_file.first == vFileInfos->fileExt)
+							{
+								vFileInfos->fileStyle = _file.second;
+							}
+						}
 						// can make sense for some dirs like the hidden by ex ".git"
-						if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType == 'd')
+						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
 						{
 							if (_file.first == vFileInfos->fileExt)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
 						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType == 'f')
+						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
 						{
 							if (_file.first == vFileInfos->fileExt)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
-						}
-						else if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType == 'l')
-						{
-							if (_file.first == vFileInfos->fileExt)
-							{
-								vFileInfos->fileStyle = _file.second;
-							}
-						}
+						}						
 					}
 					if (_flag.first & IGFD_FileStyleByFullName)
 					{
@@ -963,27 +963,27 @@ namespace IGFD
 							vFileInfos->fileStyle = _file.second;
 						}
 
-						if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType == 'd')
+						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.symlink)
 						{
 							if (_file.first == vFileInfos->fileNameExt)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
 						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType == 'f')
+						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
 						{
 							if (_file.first == vFileInfos->fileNameExt)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
 						}
-						else if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType == 'l')
+						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
 						{
 							if (_file.first == vFileInfos->fileNameExt)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
-						}
+						}						
 					}
 					if (_flag.first & IGFD_FileStyleByContainedInFullName)
 					{
@@ -992,21 +992,21 @@ namespace IGFD
 							vFileInfos->fileStyle = _file.second;
 						}
 
-						if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType == 'd')
+						if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType.symlink)
 						{
 							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
 						}
-						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType == 'f')
+						else if (_flag.first & IGFD_FileStyleByTypeDir && vFileInfos->fileType.isDir())
 						{
 							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
 							{
 								vFileInfos->fileStyle = _file.second;
 							}
 						}
-						else if (_flag.first & IGFD_FileStyleByTypeLink && vFileInfos->fileType == 'l')
+						else if (_flag.first & IGFD_FileStyleByTypeFile && vFileInfos->fileType.isFile())
 						{
 							if (vFileInfos->fileNameExt.find(_file.first) != std::string::npos)
 							{
@@ -1283,7 +1283,7 @@ namespace IGFD
 							return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) < 0); // sort in insensitive case
 						}
 						*/
-						if (a->fileType != b->fileType) return (a->fileType == 'd'); // directory in first
+						if (a->fileType != b->fileType) return (a->fileType < b->fileType); // directories first
 						return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) < 0); // sort in insensitive case
 					});
 			}
@@ -1312,7 +1312,7 @@ namespace IGFD
 							return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) > 0); // sort in insensitive case
 						}
 						*/
-						if (a->fileType != b->fileType) return (a->fileType != 'd'); // directories last
+						if (a->fileType != b->fileType) return (a->fileType > b->fileType); // directories last
 						return (stricmp(a->fileNameExt.c_str(), b->fileNameExt.c_str()) > 0); // sort in insensitive case
 					});
 			}
@@ -1330,7 +1330,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType == 'd'); // directory in first
+						if (a->fileType != b->fileType) return (a->fileType < b->fileType); // directory in first
 						return (a->fileExt < b->fileExt); // else
 					});
 			}
@@ -1345,7 +1345,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType != 'd'); // directory in last
+						if (a->fileType != b->fileType) return (a->fileType > b->fileType); // directory in last
 						return (a->fileExt > b->fileExt); // else
 					});
 			}
@@ -1363,7 +1363,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType == 'd'); // directory in first
+						if (a->fileType != b->fileType) return (a->fileType < b->fileType); // directory in first
 						return (a->fileSize < b->fileSize); // else
 					});
 			}
@@ -1378,7 +1378,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType != 'd'); // directory in last
+						if (a->fileType != b->fileType) return (a->fileType > b->fileType); // directory in last
 						return (a->fileSize > b->fileSize); // else
 					});
 			}
@@ -1396,7 +1396,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType == 'd'); // directory in first
+						if (a->fileType != b->fileType) return (a->fileType < b->fileType); // directory in first
 						return (a->fileModifDate < b->fileModifDate); // else
 					});
 			}
@@ -1411,7 +1411,7 @@ namespace IGFD
 						if (!a.use_count() || !b.use_count())
 							return false;
 
-						if (a->fileType != b->fileType) return (a->fileType != 'd'); // directory in last
+						if (a->fileType != b->fileType) return (a->fileType > b->fileType); // directory in last
 						return (a->fileModifDate > b->fileModifDate); // else
 					});
 			}
@@ -1485,7 +1485,7 @@ namespace IGFD
 		return fileNameExt;
 	}
 
-	void IGFD::FileManager::AddFile(const FileDialogInternal& vFileDialogInternal, const std::string& vPath, const std::string& vFileName, const char& vFileType)
+	void IGFD::FileManager::AddFile(const FileDialogInternal& vFileDialogInternal, const std::string& vPath, const std::string& vFileName, const FileType& vFileType)
 	{
 		auto infos = std::make_shared<FileInfos>();
 
@@ -1499,8 +1499,8 @@ namespace IGFD
 			if (!vFileDialogInternal.puFilterManager.puDLGFilters.empty() || (vFileDialogInternal.puFilterManager.puDLGFilters.empty() && infos->fileNameExt != ".")) // except "." if in directory mode //-V728
 				return;
 
-		if (infos->fileType == 'f' ||
-			infos->fileType == 'l') // link can have the same extention of a file
+		if (infos->fileType.isFile()
+			|| infos->fileType.isLinkToUnknown()) // link can have the same extention of a file
 		{
 			size_t lpt = infos->fileNameExt.find_last_of('.');
 			if (lpt != std::string::npos)
@@ -1520,9 +1520,9 @@ namespace IGFD
 		prFileList.push_back(infos);
 	}
 
-	void IGFD::FileManager::AddPath(const FileDialogInternal& vFileDialogInternal, const std::string& vPath, const std::string& vFileName, const char& vFileType)
+	void IGFD::FileManager::AddPath(const FileDialogInternal& vFileDialogInternal, const std::string& vPath, const std::string& vFileName, const FileType& vFileType)
 	{
-		if (vFileType != 'd')
+		if (!vFileType.isDir())
 			return;
 
 		auto infos = std::make_shared<FileInfos>();
@@ -1537,8 +1537,8 @@ namespace IGFD
 			if (!vFileDialogInternal.puFilterManager.puDLGFilters.empty() || (vFileDialogInternal.puFilterManager.puDLGFilters.empty() && infos->fileNameExt != ".")) // except "." if in directory mode //-V728
 				return;
 
-		if (infos->fileType == 'f' ||
-			infos->fileType == 'l') // link can have the same extention of a file
+		if (infos->fileType.isFile() 
+			|| infos->fileType.isLinkToUnknown()) // link can have the same extention of a file
 		{
 			size_t lpt = infos->fileNameExt.find_last_of('.');
 			if (lpt != std::string::npos)
@@ -1579,15 +1579,25 @@ namespace IGFD
 #ifdef USE_STD_FILESYSTEM
 			const std::filesystem::path fspath(path);
 			const auto dir_iter = std::filesystem::directory_iterator(fspath);
-			AddFile(vFileDialogInternal, path, "..", 'd');
+			FileType fstype = FileType(FileType::Directory, std::filesystem::is_symlink(std::filesystem::status(fspath)));
+			AddFile(vFileDialogInternal, path, "..", fstype);
 			for (const auto& file : dir_iter)
 			{
-				char fileType = 0; 
-				if (file.is_directory()) { fileType = 'd'; } // directory or symlink to directory
-				else if (file.is_symlink()) { fileType = 'l'; } // file
-				else { fileType = 'f'; }
-				auto fileNameExt = file.path().filename().string();
-				AddFile(vFileDialogInternal, path, fileNameExt, fileType);
+				FileType fileType;
+				if (file.is_symlink())
+				{
+					fileType.symlink = file.is_symlink();
+					fileType.content = FileType::LinkToUnknown;
+				}
+				
+				if (file.is_directory()) { fileType.content = FileType::Directory; } // directory or symlink to directory
+				else if (file.is_regular_file()) { fileType.content = FileType::File; }
+
+				if (fileType.isValid())
+				{
+					auto fileNameExt = file.path().filename().string();
+					AddFile(vFileDialogInternal, path, fileNameExt, fileType);
+				}
 			}
 #else // dirent
 			struct dirent** files = nullptr;
@@ -1600,20 +1610,41 @@ namespace IGFD
 				{
 					struct dirent* ent = files[i];
 
-					char fileType = 0;
+					FileType fileType;
 					switch (ent->d_type)
 					{
 					case DT_DIR:
-						fileType = 'd'; break;
-					case DT_LNK:
-						fileType = 'l'; break;
+						fileType.content = FileType::Directory; break;
 					case DT_REG:
-						fileType = 'f'; break;
+						fileType.content = FileType::File; break;
+					case DT_LNK:
+					{
+						fileType.symlink = true;
+						fileType.content = FileType::LinkToUnknown; // by default if we can't figure out the target type.
+						struct stat statInfos = {};
+						int result = stat((path + PATH_SEP + ent->d_name).c_str(), &statInfos);
+						if (result == 0)
+						{
+							if (statInfos.st_mode & S_IFREG)
+							{
+								fileType.content = FileType::File;
+							}
+							else if (statInfos.st_mode & S_IFDIR)
+							{
+								fileType.content = FileType::Directory;
+							}
+						}
+						break;
+					}
+					default:
+						break; // leave it invalid (devices, etc.)
 					}
 
-					auto fileNameExt = ent->d_name;
-
-					AddFile(vFileDialogInternal, path, fileNameExt, fileType);
+					if (fileType.isValid())
+					{
+						auto fileNameExt = ent->d_name;
+						AddFile(vFileDialogInternal, path, fileNameExt, fileType);
+					}
 				}
 
 				for (i = 0; i < n; i++)
@@ -1716,7 +1747,7 @@ namespace IGFD
 				auto info = std::make_shared<FileInfos>();
 				info->fileNameExt = drive;
 				info->fileNameExt_optimized = prOptimizeFilenameForSearchOperations(drive);
-				info->fileType = 'd';
+				info->fileType.content = FileType::Directory;
 
 				if (!info->fileNameExt.empty())
 				{
@@ -1839,7 +1870,7 @@ namespace IGFD
 			bool show = true;
 			if (!file->IsTagFound(vFileDialogInternal.puSearchManager.puSearchTag))  // if search tag
 				show = false;
-			if (puDLGDirectoryMode && file->fileType != 'd') // directory mode
+			if (puDLGDirectoryMode && !file->fileType.isDir())
 				show = false;
 			if (show)
 				vFileInfosFilteredList.push_back(file);
@@ -1901,7 +1932,8 @@ namespace IGFD
 
 			std::string fpn;
 
-			if (vInfos->fileType == 'f' || vInfos->fileType == 'l' || vInfos->fileType == 'd') // file
+			// FIXME: so the condition is always true?
+			if (vInfos->fileType.isFile() || vInfos->fileType.isLinkToUnknown() || vInfos->fileType.isDir())
 				fpn = vInfos->filePath + std::string(1u, PATH_SEP) + vInfos->fileNameExt;
 
 			struct stat statInfos = {};
@@ -1909,7 +1941,7 @@ namespace IGFD
 			int result = stat(fpn.c_str(), &statInfos);
 			if (!result)
 			{
-				if (vInfos->fileType != 'd')
+				if (!vInfos->fileType.isDir())
 				{
 					vInfos->fileSize = (size_t)statInfos.st_size;
 					vInfos->formatedFileSize = prFormatFileSize(vInfos->fileSize);
@@ -4276,7 +4308,7 @@ namespace IGFD
 #endif // USE_EXPLORATION_BY_KEYS
 		if (res)
 		{
-			if (vInfos->fileType == 'd')
+			if (vInfos->fileType.isDir())
 			{
 				// nav system, selectable cause open directory or select directory
 				if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard)
@@ -4327,9 +4359,9 @@ namespace IGFD
 		}
 
 		if (vOutShowColor && !vFileInfos->fileStyle->icon.empty()) vOutStr = vFileInfos->fileStyle->icon;
-		else if (vFileInfos->fileType == 'd') vOutStr = dirEntryString;
-		else if (vFileInfos->fileType == 'l') vOutStr = linkEntryString;
-		else if (vFileInfos->fileType == 'f') vOutStr = fileEntryString;
+		else if (vFileInfos->fileType.isDir()) vOutStr = dirEntryString;
+		else if (vFileInfos->fileType.isLinkToUnknown()) vOutStr = linkEntryString;
+		else if (vFileInfos->fileType.isFile()) vOutStr = fileEntryString;
 
 		vOutStr += " " + vFileInfos->fileNameExt;
 
@@ -4497,7 +4529,7 @@ namespace IGFD
 						}
 						if (ImGui::TableNextColumn()) // file size
 						{
-							if (infos->fileType != 'd')
+							if (!infos->fileType.isDir())
 							{
 								ImGui::Text("%s ", infos->formatedFileSize.c_str());
 							}

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -860,7 +860,6 @@ namespace IGFD
 		bool operator!= (const FileType& rhs) const { return m_Content != rhs.m_Content; }
 		bool operator<  (const FileType& rhs) const { return m_Content < rhs.m_Content; }
 		bool operator>  (const FileType& rhs) const { return m_Content > rhs.m_Content; }
-
 	};
 
 	class FileInfos

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -825,34 +825,42 @@ namespace IGFD
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	struct FileType
+	class FileType
 	{
+	public:
 		enum ContentType {
 			// The ordering will be used during sort.
 			Invalid = -1,
 			Directory = 0,
 			File = 1,
 			LinkToUnknown = 2, // link to something that is not a regular file or directory.
-		} content;
+		};
 
-		FileType () {}
+	private:
+		ContentType m_Content;
+		bool m_Symlink = false;
 
-		FileType (ContentType contentType, bool symlink)
-		: content (contentType), symlink (symlink)
+	public:
+		FileType() = default;
+		FileType(const ContentType& vContentType, const bool& vIsSymlink)
+			: m_Content(vContentType), m_Symlink(vIsSymlink)
 		{}
 
-		bool isValid () const { return content != Invalid; }
-		bool isDir () const { return content == Directory; }
-		bool isFile () const { return content == File; }
-		bool isLinkToUnknown () const { return content == LinkToUnknown; }
+		void SetContent(const ContentType& vContentType) { m_Content = vContentType; }
+		void SetSymLink(const bool& vIsSymlink) { m_Symlink = vIsSymlink; }
+
+		bool isValid () const { return m_Content != ContentType::Invalid; }
+		bool isDir () const { return m_Content == ContentType::Directory; }
+		bool isFile () const { return m_Content == ContentType::File; }
+		bool isLinkToUnknown () const { return m_Content == ContentType::LinkToUnknown; }
+		bool isSymLink() const { return m_Symlink; }
 
 		// Comparisons only care about the content type, ignoring whether it's a symlink or not.
-		bool operator== (const FileType& rhs) const { return content == rhs.content; }
-		bool operator!= (const FileType& rhs) const { return content != rhs.content; }
-		bool operator<  (const FileType& rhs) const { return content < rhs.content; }
-		bool operator>  (const FileType& rhs) const { return content > rhs.content; }
+		bool operator== (const FileType& rhs) const { return m_Content == rhs.m_Content; }
+		bool operator!= (const FileType& rhs) const { return m_Content != rhs.m_Content; }
+		bool operator<  (const FileType& rhs) const { return m_Content < rhs.m_Content; }
+		bool operator>  (const FileType& rhs) const { return m_Content > rhs.m_Content; }
 
-		bool symlink = false;
 	};
 
 	class FileInfos

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -865,7 +865,7 @@ namespace IGFD
 	class FileInfos
 	{
 	public:
-		FileType fileType;    								// dirent fileType (f:file, d:directory, l:link)				
+		FileType fileType;    								// fileType		
 		std::string filePath;								// path of the file
 		std::string fileNameExt;							// filename of the file (file name + extention) (but no path)
 		std::string fileNameExt_optimized;					// optimized for search => insensitivecase

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -825,10 +825,40 @@ namespace IGFD
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	struct FileType
+	{
+		enum ContentType {
+			// The ordering will be used during sort.
+			Invalid = -1,
+			Directory = 0,
+			File = 1,
+			LinkToUnknown = 2, // link to something that is not a regular file or directory.
+		} content;
+
+		FileType () {}
+
+		FileType (ContentType contentType, bool symlink)
+		: content (contentType), symlink (symlink)
+		{}
+
+		bool isValid () const { return content != Invalid; }
+		bool isDir () const { return content == Directory; }
+		bool isFile () const { return content == File; }
+		bool isLinkToUnknown () const { return content == LinkToUnknown; }
+
+		// Comparisons only care about the content type, ignoring whether it's a symlink or not.
+		bool operator== (const FileType& rhs) const { return content == rhs.content; }
+		bool operator!= (const FileType& rhs) const { return content != rhs.content; }
+		bool operator<  (const FileType& rhs) const { return content < rhs.content; }
+		bool operator>  (const FileType& rhs) const { return content > rhs.content; }
+
+		bool symlink = false;
+	};
+
 	class FileInfos
 	{
 	public:
-		char fileType = ' ';								// dirent fileType (f:file, d:directory, l:link)				
+		FileType fileType;    								// dirent fileType (f:file, d:directory, l:link)				
 		std::string filePath;								// path of the file
 		std::string fileNameExt;							// filename of the file (file name + extention) (but no path)
 		std::string fileNameExt_optimized;					// optimized for search => insensitivecase
@@ -921,9 +951,9 @@ namespace IGFD
 		void prRemoveFileNameInSelection(const std::string& vFileName);									// selection : remove a file name
 		void prAddFileNameInSelection(const std::string& vFileName, bool vSetLastSelectionFileName);	// selection : add a file name
 		void AddFile(const FileDialogInternal& vFileDialogInternal, 
-			const std::string& vPath, const std::string& vFileName, const char& vFileType);				// add file called by scandir
+			const std::string& vPath, const std::string& vFileName, const FileType& vFileType);		    // add file called by scandir
 		void AddPath(const FileDialogInternal& vFileDialogInternal,
-			const std::string& vPath, const std::string& vFileName, const char& vFileType);				// add file called by scandir
+			const std::string& vPath, const std::string& vFileName, const FileType& vFileType);			// add file called by scandir
 
 #if defined(USE_QUICK_PATH_SELECT)
 		void ScanDirForPathSelection(const FileDialogInternal& vFileDialogInternal, const std::string& vPath);	// scan the directory for retrieve the path list


### PR DESCRIPTION
It introduces a FileType struct that keeps track of both the target content type and whether the item was a symlink. So the style of links can still be customized, but for more purposes symlinks to valid files or directories behaves like their target. Only broken links or links towards devices, etc. would still appear as [Link].

The struct also handles comparisons, which makes the sorting code a bit simpler and fixes the issue where links can ends up in a non-deterministic location.

Made it a draft PR as I haven't done extensive testing on all platforms, just tested locally on Ubuntu in my app. So it's more of a proof of concept at this stage to feed the discussion in #88 , but if there is interest to merge something like this I'd be happy to polish it a bit.
