### PR TITLE
Use the default extension event with the full filter syntax.

### DIFF
--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -1041,14 +1041,15 @@ namespace IGFD
 		public:
 			std::string filter;																				// simple filter
 			std::regex filter_regex;																		// filter fo type regex
-			std::set<std::string> collectionfilters;														// collections of filters
+			std::vector<std::string> collectionfilters;														// collections of filters
 			std::string filter_optimized;																	// opitmized for case insensitive search
-			std::set<std::string> collectionfilters_optimized;												// optimized collections of filters for case insensitive search
+			std::vector<std::string> collectionfilters_optimized;												// optimized collections of filters for case insensitive search
 			std::vector<std::regex> collectionfilters_regex;												// collection of regex filter type
 
 		public:
 			void clear();																					// clear the datas
 			bool empty() const;																				// is filter empty
+                        std::string default_extension() const;
 			bool exist(const std::string& vFilter, bool vIsCaseInsensitive) const;							// is filter exist
 			bool regex_exist(const std::string& vFilter) const;												// is regex filter exist
 		};


### PR DESCRIPTION
I am using a filter such as `"Foobar (*.bar) {.bar},All files {.*}"`, then the user types a file without extension, lets say `"x"`. I would expect the final file to be `"x.bar"` but it is just `"x"` instead.

This is because the logic that adds the default extension does so only if you use the plain syntax `".bar"`. I've modified it to use the first extension present in the filter.

I think that is many other UI toolkits do and what I would expect.

To remember the order of the filters, I changed the `std::set` to `std::vector`. For real world cases (2-5 extensions) that should even be even slightly faster.  