### PR TITLE
Fix for catching exception by value.

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -550,7 +550,7 @@ namespace IGFD
 				const auto dir_iter = std::filesystem::directory_iterator(pathName);
 				(void)dir_iter; // for avoid unused warnings
 			}
-			catch (std::exception /*ex*/)
+			catch (const std::exception & /*ex*/)
 			{
 				// fail so this dir cant be opened
 				bExists = false;


### PR DESCRIPTION
When std::filesystem is used then exceptions were catch that way:
```cpp
try {
  ...
}
catch(std::exception /*ex*/) {...}
```
It's a bad style because exceptions should be catch by a reference to a base class, not by a value. And modern compilers (like g++10) produce warnings on code like that.

This PR fixes the use of std::exception in a `catch` statement.