### PR TITLE
Checkbox to show hidden files

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -196,6 +196,12 @@ namespace IGFD
 #ifndef buttonCreateDirString
 #define buttonCreateDirString "Create Directory"
 #endif // buttonCreateDirString
+#ifndef buttonShowHiddenString
+#define buttonShowHiddenString "Show hidden"
+#endif // buttonShowHiddenString
+#ifndef tooltipShowHiddenString
+#define tooltipShowHiddenString "Toggle hidden"
+#endif // tooltipShowHiddenString
 #ifndef tableHeaderAscendingIcon
 #define tableHeaderAscendingIcon "A|"
 #endif // tableHeaderAscendingIcon
@@ -4287,6 +4293,24 @@ namespace IGFD
 		ImGui::EndGroup();
 
 		prOkCancelButtonWidth = ImGui::GetItemRectSize().x;
+
+		// Only show the hidden files toggle if there is enough horizontal space for it.
+		// The width is calculated as in https://github.com/ocornut/imgui/issues/3714#issuecomment-759319268
+		float const toggleWidth = GImGui->Style.ItemSpacing.x + ImGui::GetFrameHeight() + GImGui->Style.ItemInnerSpacing.x + ImGui::CalcTextSize(buttonShowHiddenString).x;
+		float const toggleOffsetX = ImGui::GetContentRegionAvail().x - toggleWidth;
+		if (toggleOffsetX >= prOkCancelButtonWidth)
+		{
+			ImGui::SameLine();
+			ImGui::SetCursorPosX(toggleOffsetX);
+			bool showHidden = ! (prFileDialogInternal.puDLGflags & ImGuiFileDialogFlags_DontShowHiddenFiles);
+			if (ImGui::Checkbox(buttonShowHiddenString, &showHidden))
+			{
+				prFileDialogInternal.puDLGflags ^= ImGuiFileDialogFlags_DontShowHiddenFiles;
+				prFileDialogInternal.puFileManager.OpenCurrentPath(prFileDialogInternal);
+			}
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip(tooltipShowHiddenString);
+		}
 
 		return res;
 	}

--- a/ImGuiFileDialogConfig.h
+++ b/ImGuiFileDialogConfig.h
@@ -75,6 +75,7 @@
 //#define buttonEditPathString "Edit path\nYou can also right click on path buttons"
 //#define buttonResetPathString "Reset to current directory"
 //#define buttonCreateDirString "Create Directory"
+//#define buttonShowHiddenString "Show hidden"
 //#define OverWriteDialogTitleString "The file Already Exist !"
 //#define OverWriteDialogMessageString "Would you like to OverWrite it ?"
 //#define OverWriteDialogConfirmButtonString "Confirm"


### PR DESCRIPTION
Add a toggle to dialog footers to change visibility of hidden files. When pressed, the contents of the file window get refreshed (the selectionis kept, if any). The extra widget only appears if there is enough horizontal space left after Ok/Cancel buttons.