### PR TITLE
Fix a bug where the files for multiple selected directories are wrong

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -2487,7 +2487,7 @@ IGFD_API std::string IGFD::FileManager::GetResultingPath() {
     std::string path = prCurrentPath;
     if (puDLGDirectoryMode) { // if directory mode
         std::string selectedDirectory = puFileNameBuffer;
-        if (!selectedDirectory.empty() && selectedDirectory != ".") {
+        if (prSelectedFileNames.size() == 1 && !selectedDirectory.empty() && selectedDirectory != ".") {
             path += std::string(1u, PATH_SEP) + selectedDirectory;
         }
     }


### PR DESCRIPTION

When selecting a directory and when having chosen multiple directories, the resulting entries in the selection (from `IGFD_GetSelection(ImGuiFileDialog::Instance())`) have a paths like `..../6 Files Selected/...`.. The change fixes this for my use case.