### PR TITLE
Update minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(ImGuiFileDialog)
 


### PR DESCRIPTION
Hello.
I use this project with CMake. The problem is that CMake deprecates everything below 3.5 and it generates a deprecation warning when configuring projects with a minimum version lower than 3.5.

I wanted to get rid of this warning in my projects, so that's why I increased the minimum version from `3.1` to `3.5` and I propose this change here.

Really nothing can go wrong with this change, but for the sake of it, I tested it on Linux and Windows with CMake `3.27.X` and nothing breaks.