### PR TITLE
Suppress unknown pragmas for other compilers (non-MSVC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,8 @@ add_library(ImGuiFileDialog STATIC
     ImGuiFileDialogConfig.h
 )
 
-target_include_directories(ImGuiFileDialog PUBLIC 
-	${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ImGuiFileDialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(UNIX)
+    target_compile_options(ImGuiFileDialog PUBLIC "-Wno-unknown-pragmas")
+endif()


### PR DESCRIPTION
As changing `-Wunknown-pragmas` in code doesn't seem to be working, one other option would be to suppress unknown pragmas from the command line. It's for GCC and Clang.
This fixes issue #138.