### PR TITLE
Fix: Extension seperator in default filename gets removed

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3748,7 +3748,9 @@ IGFD_API bool IGFD::FileDialog::Display(
 
                 // init list of files
                 if (fdFile.IsFileListEmpty() && !fdFile.puShowDrives) {
-                    IGFD::Utils::ReplaceString(fdFile.puDLGDefaultFileName, fdFile.puDLGpath, "");  // local path
+                    if (fdFile.puDLGpath != ".") // Removes extension seperator in filename if we don't check
+                        IGFD::Utils::ReplaceString(fdFile.puDLGDefaultFileName, fdFile.puDLGpath, "");  // local path
+                    
                     if (!fdFile.puDLGDefaultFileName.empty()) {
                         fdFile.SetDefaultFileName(fdFile.puDLGDefaultFileName);
                         fdFilter.SetSelectedFilterWithExt(fdFilter.puDLGdefaultExt);


### PR DESCRIPTION
The extension seperator (the dot) in the default filename got removed if the path was set to the working directory (".') due to a string replace. Now it gets checked before the replace