### PR TITLE
Configuration file CMake Config Switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ImGuiFileDialog)
 
 set(IMGUI_FILEDIALOG_CONFIG "ImGuiFileDialogConfig.h" CACHE FILEPATH "Change this to supply a custom ImGuiFileDialogConfig.h")
 
-add_library(ImGuiFileDialog STATIC
+add_library(ImGuiFileDialog
     ImGuiFileDialog.cpp
     ImGuiFileDialog.h
     ${IMGUI_FILEDIALOG_CONFIG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,16 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ImGuiFileDialog)
 
+set(IMGUI_FILEDIALOG_CONFIG "ImGuiFileDialogConfig.h" CACHE FILEPATH "Change this to supply a custom ImGuiFileDialogConfig.h")
+
 add_library(ImGuiFileDialog STATIC
     ImGuiFileDialog.cpp
     ImGuiFileDialog.h
-    ImGuiFileDialogConfig.h
+    ${IMGUI_FILEDIALOG_CONFIG}
 )
 
 target_include_directories(ImGuiFileDialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(ImGuiFileDialog PRIVATE CUSTOM_IMGUIFILEDIALOG_CONFIG="${IMGUI_FILEDIALOG_CONFIG}")
 
 if(UNIX)
     target_compile_options(ImGuiFileDialog PUBLIC "-Wno-unknown-pragmas")


### PR DESCRIPTION
Hello,

currently for integrating this project with a custom configuration file it is necessary to add the source files manually to an add_executable / add_library call. This is because the default configuration file is currently baked in the existing CMake target.

This pull request changes this, and adds a CMake Variable for specifying the configuration file. With this it is possible to integrate the project like this:

```
...
set(IMGUI_FILEDIALOG_CONFIG CustomImGuiFileDialogConfig.h)
add_subdirectory(deps/ImGuiFileDialog)

...

add_library(test ...)
target_link_libraries(test PRIVATE ImGuiFileDialog)
```

This is more in line with how CMake is supposed to be used and allows you as the library creator to change the names of the source files or add new ones, without legacy projects needing to change their CMakeLists.txt every time a new source file appears.

It also doesn't break legacy compatibility for ppl using the old approach, as there is no change in the source files themselves.

Maybe a change of the integration description in the README / Sourcefiles should also be added.

