### PR TITLE
Replace busy waiting with condition variable, fix race condition

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -2725,7 +2725,10 @@ void IGFD::ThumbnailFeature::m_StartThumbnailFileDatasExtraction() {
         m_CountFiles                = 0U;
         m_ThumbnailGenerationThread = std::shared_ptr<std::thread>(new std::thread(&IGFD::ThumbnailFeature::m_ThreadThumbnailFileDatasExtractionFunc, this), [this](std::thread* obj) {
             m_IsWorking = false;
-            if (obj) obj->join();
+            if (obj) {
+                m_ThumbnailFileDatasToGetCv.notify_all();
+                obj->join();
+            }
         });
     }
 }
@@ -2745,12 +2748,14 @@ void IGFD::ThumbnailFeature::m_ThreadThumbnailFileDatasExtractionFunc() {
 
     // infinite loop while is thread working
     while (m_IsWorking) {
+        std::unique_lock<std::mutex> thumbnailFileDatasToGetLock(m_ThumbnailFileDatasToGetMutex);
+        m_ThumbnailFileDatasToGetCv.wait(thumbnailFileDatasToGetLock);
         if (!m_ThumbnailFileDatasToGet.empty()) {
             std::shared_ptr<FileInfos> file = nullptr;
-            m_ThumbnailFileDatasToGetMutex.lock();
             // get the first file in the list
             file = (*m_ThumbnailFileDatasToGet.begin());
-            m_ThumbnailFileDatasToGetMutex.unlock();
+            m_ThumbnailFileDatasToGet.pop_front();
+            thumbnailFileDatasToGetLock.unlock();
 
             // retrieve datas of the texture file if its an image file
             if (file.use_count()) {
@@ -2803,16 +2808,9 @@ void IGFD::ThumbnailFeature::m_ThreadThumbnailFileDatasExtractionFunc() {
                         }
                     }
                 }
-
-                // peu importe le resultat on vire le fichier
-                // remove form this list
-                // write => thread concurency issues
-                m_ThumbnailFileDatasToGetMutex.lock();
-                m_ThumbnailFileDatasToGet.pop_front();
-                m_ThumbnailFileDatasToGetMutex.unlock();
             }
         } else {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            thumbnailFileDatasToGetLock.unlock();
         }
     }
 }
@@ -2849,6 +2847,7 @@ void IGFD::ThumbnailFeature::m_AddThumbnailToLoad(const std::shared_ptr<FileInfo
                 m_ThumbnailFileDatasToGet.push_back(vFileInfos);
                 vFileInfos->thumbnailInfo.isLoadingOrLoaded = true;
                 m_ThumbnailFileDatasToGetMutex.unlock();
+                m_ThumbnailFileDatasToGetCv.notify_all();
             }
         }
     }
@@ -2913,16 +2912,16 @@ void IGFD::ThumbnailFeature::SetDestroyThumbnailCallback(const DestroyThumbnailF
 
 void IGFD::ThumbnailFeature::ManageGPUThumbnails() {
     if (m_CreateThumbnailFun) {
+        m_ThumbnailToCreateMutex.lock();
         if (!m_ThumbnailToCreate.empty()) {
             for (const auto& file : m_ThumbnailToCreate) {
                 if (file.use_count()) {
                     m_CreateThumbnailFun(&file->thumbnailInfo);
                 }
             }
-            m_ThumbnailToCreateMutex.lock();
             m_ThumbnailToCreate.clear();
-            m_ThumbnailToCreateMutex.unlock();
         }
+        m_ThumbnailToCreateMutex.unlock();
     } else {
         printf(
             "No Callback found for create texture\nYou need to define the callback with a call to "
@@ -2930,14 +2929,14 @@ void IGFD::ThumbnailFeature::ManageGPUThumbnails() {
     }
 
     if (m_DestroyThumbnailFun) {
+        m_ThumbnailToDestroyMutex.lock();
         if (!m_ThumbnailToDestroy.empty()) {
             for (auto thumbnail : m_ThumbnailToDestroy) {
                 m_DestroyThumbnailFun(&thumbnail);
             }
-            m_ThumbnailToDestroyMutex.lock();
             m_ThumbnailToDestroy.clear();
-            m_ThumbnailToDestroyMutex.unlock();
         }
+        m_ThumbnailToDestroyMutex.unlock();
     } else {
         printf(
             "No Callback found for destroy texture\nYou need to define the callback with a call to "

--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -1362,6 +1362,7 @@ struct IGFD_Thumbnail_Info {
 #include <regex>
 #include <array>
 #include <mutex>
+#include <condition_variable>
 #include <thread>
 #include <cfloat>
 #include <memory>
@@ -1980,6 +1981,7 @@ private:
     std::shared_ptr<std::thread> m_ThumbnailGenerationThread = nullptr;
     std::list<std::shared_ptr<FileInfos>> m_ThumbnailFileDatasToGet;  // base container
     std::mutex m_ThumbnailFileDatasToGetMutex;
+    std::condition_variable m_ThumbnailFileDatasToGetCv;
     std::list<std::shared_ptr<FileInfos>> m_ThumbnailToCreate;  // base container
     std::mutex m_ThumbnailToCreateMutex;
     std::list<IGFD_Thumbnail_Info> m_ThumbnailToDestroy;  // base container


### PR DESCRIPTION
This PR replaces busy waiting with `sleep_for` through the use of a condition variable.
Also, it fixes a race condition (that I sometimes encountered in release mode on Linux) that happens due to `clear` being guarded by a mutex, but `empty` not being guarded.