### PR TITLE
Address compilation error on Mac OS and Linux

### DIFF
--- a/ImGuiFileDialog.h
+++ b/ImGuiFileDialog.h
@@ -1244,6 +1244,8 @@ enum IGFD_FileStyleFlags_         // by evaluation / priority order
 
 #pragma endregion
 
+#include <cstdint>
+
 #pragma region FLAGS : ImGuiFileDialogFlags
 
 typedef int ImGuiFileDialogFlags;  // -> enum ImGuiFileDialogFlags_


### PR DESCRIPTION
Good afternoon

I was trying to get ImGuiFileDialog to work on my side and it would not build.
As it turns out there was already an [issue](https://github.com/aiekick/ImGuiFileDialog/issues/176) open.

This is a simple fix, however I do not know if this is where you want the header included. I used cstdint because cfloat is also in the headers, figured I'd take the same approach.

Let me know if there's something you want me to change.