### PR TITLE
[FIX] : Set `m_CurrentDisplayedFlags` to `vFlags`

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3758,7 +3758,7 @@ bool IGFD::FileDialog::Display(const std::string& vKey, ImGuiWindowFlags vFlags,
         }
         m_FileDialogInternal.lastImGuiFrameCount = g.FrameCount;  // mark this instance as used this frame
 
-        m_CurrentDisplayedFlags = ImGuiWindowFlags_None;
+        m_CurrentDisplayedFlags = vFlags;
         std::string name        = m_FileDialogInternal.dLGtitle + "##" + m_FileDialogInternal.dLGkey;
         if (m_FileDialogInternal.name != name) {
             fdFile.ClearComposer();

--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3763,7 +3763,6 @@ bool IGFD::FileDialog::Display(const std::string& vKey, ImGuiWindowFlags vFlags,
         if (m_FileDialogInternal.name != name) {
             fdFile.ClearComposer();
             fdFile.ClearFileLists();
-            m_CurrentDisplayedFlags = vFlags;
         }
 
         m_NewFrame();


### PR DESCRIPTION
Avoid `m_CurrentDisplayedFlags` not being set to `vFlags` when `m_FileDialogInternal.name == name`. `m_FileDialogInternal.name` is set to `name` in the initial call to the function `Display` as you can see in the line 3811.