### PR TITLE
cmake: enable package manager support with install/export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(IGFD_INSTALL "Install ImGuiFileDialog library and headers" ${IGFD_INSTALL
 
 find_package(imgui QUIET) # fails quietly if not found (imgui is the target name for vcpkg and nixpkgs).
 
-add_library(ImGuiFileDialog STATIC
+add_library(ImGuiFileDialog
     ImGuiFileDialog.cpp
     ImGuiFileDialog.h
     ImGuiFileDialogConfig.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if(IGFD_INSTALL)
     # Install export targets
     install(EXPORT ImGuiFileDialogTargets
        FILE ImGuiFileDialogConfig.cmake
+       NAMESPACE ImGuiFileDialog::
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGuiFileDialog
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.20)
-
 project(ImGuiFileDialog)
 
 add_library(ImGuiFileDialog STATIC
@@ -8,8 +7,37 @@ add_library(ImGuiFileDialog STATIC
     ImGuiFileDialogConfig.h
 )
 
-target_include_directories(ImGuiFileDialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# Use generator expressions for proper include directory handling
+target_include_directories(ImGuiFileDialog
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include>
+)
 
 if(UNIX)
     target_compile_options(ImGuiFileDialog PUBLIC -Wno-unknown-pragmas)
 endif()
+
+# Installation configuration
+include(GNUInstallDirs)
+
+# Install the library
+install(TARGETS ImGuiFileDialog
+    EXPORT ImGuiFileDialogTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Install headers
+install(FILES 
+    ImGuiFileDialog.h 
+    ImGuiFileDialogConfig.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Install export targets
+install(EXPORT ImGuiFileDialogTargets
+    FILE ImGuiFileDialogConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGuiFileDialog
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,29 @@
 cmake_minimum_required(VERSION 3.20)
 project(ImGuiFileDialog)
 
+# Option to control installation (disabled by default if used as subproject)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(IGFD_INSTALL_DEFAULT ON)
+else()
+    set(IGFD_INSTALL_DEFAULT OFF)
+endif()
+
+option(IGFD_INSTALL "Install ImGuiFileDialog library and headers" ${IGFD_INSTALL_DEFAULT})
+
+find_package(imgui QUIET) # fails quietly if not found (imgui is the target name for vcpkg and nixpkgs).
+
 add_library(ImGuiFileDialog STATIC
     ImGuiFileDialog.cpp
     ImGuiFileDialog.h
     ImGuiFileDialogConfig.h
 )
+
+if(imgui_FOUND)
+    target_link_libraries(ImGuiFileDialog PUBLIC imgui::imgui)
+    message(STATUS "ImGuiFileDialog: Found imgui package, linking automatically")
+else()
+    message(STATUS "ImGuiFileDialog: imgui package not found - ensure ImGui is available in your project")
+endif()
 
 # Use generator expressions for proper include directory handling
 target_include_directories(ImGuiFileDialog
@@ -19,25 +37,27 @@ if(UNIX)
 endif()
 
 # Installation configuration
-include(GNUInstallDirs)
+if(IGFD_INSTALL)
+    include(GNUInstallDirs)
 
-# Install the library
-install(TARGETS ImGuiFileDialog
-    EXPORT ImGuiFileDialogTargets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+    # Install the library
+    install(TARGETS ImGuiFileDialog
+       EXPORT ImGuiFileDialogTargets
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-# Install headers
-install(FILES 
-    ImGuiFileDialog.h 
-    ImGuiFileDialogConfig.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    # Install headers
+    install(FILES 
+       ImGuiFileDialog.h 
+       ImGuiFileDialogConfig.h
+       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
-# Install export targets
-install(EXPORT ImGuiFileDialogTargets
-    FILE ImGuiFileDialogConfig.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGuiFileDialog
-)
+    # Install export targets
+    install(EXPORT ImGuiFileDialogTargets
+       FILE ImGuiFileDialogConfig.cmake
+       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGuiFileDialog
+    )
+endif()


### PR DESCRIPTION
This PR adds installation and export capabilities to enable integration with package managers like vcpkg, Conan, xrepo, and Nix.

Changes:

- Added install() commands for library and headers
- Added CMake export targets for find_package() support
- Used generator expressions for proper include directory handling

This enables packaging for vcpkg, Conan, Nix, and system package managers, and allows downstream projects to use find_package(ImGuiFileDialog REQUIRED).

The current CMakeLists.txt only defines the library target without installation support, making it difficult for package managers to properly distribute the library. This PR solves that while keeping all existing workflows unchanged.