### PR TITLE
Add support for Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+label_flag(
+    name = "config",
+    build_setting_default = ":default_config",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "default_config",
+    hdrs = ["ImGuiFileDialogConfig.h"],
+    include_prefix = ".",
+)
+
+cc_library(
+    name = "imguifiledialog",
+    srcs = [
+        "ImGuiFileDialog.cpp",
+        "dirent/dirent.h",
+        "stb/stb_image.h",
+        "stb/stb_image_resize2.h",
+    ],
+    hdrs = [
+        "ImGuiFileDialog.h",
+    ],
+    include_prefix = ".",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        "@imgui",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "imguifiledialog",
+    version = "0.6.8",
+)
+
+bazel_dep(name = "imgui", version = "1.92.6-docking")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/README.md
+++ b/README.md
@@ -174,6 +174,50 @@ you need many lib : opengl and cocoa framework
 
 </blockquote></details>
 
+### In Bazel
+
+`ImGuiFileDialog` supports [Bazel](https://bazel.build/) using Bzlmod (Bazel 7+).
+
+#### Integration
+
+Since the module is not yet available in the Bazel Central Registry (BCR), you must add it to your `MODULE.bazel` using either an `http_archive` or `new_local_repository`.
+
+In your `BUILD` file, add the dependency to your target:
+
+```python
+cc_binary(
+    name = "my_app",
+    srcs = ["main.cpp"],
+    deps = ["@imguifiledialog"],
+)
+```
+
+#### Customization
+
+Create a header file in your project named **`ImGuiFileDialogConfig.h`** and define your custom values.
+
+In your local `BUILD` file, wrap that header in a `cc_library`. You must use `include_prefix` or `includes` to ensure the library can find it as `"ImGuiFileDialogConfig.h"`.
+
+```python
+cc_library(
+    name = "imguifiledialog_config",
+    hdrs = ["ImGuiFileDialogConfig.h"],
+    include_prefix = ".", 
+)
+```
+
+You can apply this override via the command line:
+
+```bash
+bazel build //... --@imguifiledialog//:config=//path/to/my:imguifiledialog_config
+```
+
+Or make it permanent for your project by adding it to your `.bazelrc`:
+
+```bash
+build --@imguifiledialog//:config=//path/to/my:imguifiledialog_config
+```
+
 ## That's all folks :-)
 
 You can check by example in this repo with the file CustomImGuiFileDialogConfig.h :


### PR DESCRIPTION
This adds the necessary bazel files so that the library can be easily integrated. Ideally the module would also be added to https://registry.bazel.build