### PR TITLE
fix: prevent nullptr dereference in GetCurrentWindowRead calls

### DIFF
--- a/ImGuiFileDialog.cpp
+++ b/ImGuiFileDialog.cpp
@@ -3877,7 +3877,7 @@ bool IGFD::FileDialog::Display(const std::string& vKey, ImGuiWindowFlags vFlags,
                 m_CurrentDisplayedFlags = vFlags;
             } else {
                 auto win = ImGui::GetCurrentWindowRead();
-                if (win->Viewport->Idx != 0)
+                if (win && win->Viewport->Idx != 0)
                     m_CurrentDisplayedFlags |= ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar;
                 else
                     m_CurrentDisplayedFlags = vFlags;
@@ -3914,7 +3914,10 @@ bool IGFD::FileDialog::Display(const std::string& vKey, ImGuiWindowFlags vFlags,
             ImGui::EndChild();
 
             // for display in dialog center, the confirm to overwrite dlg
-            m_FileDialogInternal.dialogCenterPos = ImGui::GetCurrentWindowRead()->ContentRegionRect.GetCenter();
+            auto* win = ImGui::GetCurrentWindowRead();
+            if(win){
+                m_FileDialogInternal.dialogCenterPos = win->ContentRegionRect.GetCenter();
+            }
 
             // when the confirm to overwrite dialog will appear we need to
             // disable the modal mode of the main file dialog


### PR DESCRIPTION
Problem:
Crashes occur when `ImGui::GetCurrentWindowRead()` returns nullptr, which can happen:

After `ImGui::EndChild()`
During modal dialog transitions
In multi-viewport configurations

Solution:
Added null pointer checks before dereferencing window pointers in two locations:
- Check win pointer before accessing Viewport->Idx at line 3880
- Check win pointer before accessing ContentRegionRect at line 3917
